### PR TITLE
fix: increase OS disk size to 30GB for Debian 12 compatibility

### DIFF
--- a/virtual-machines.tf
+++ b/virtual-machines.tf
@@ -88,7 +88,7 @@ resource "azurerm_linux_virtual_machine" "vm_micro" {
   os_disk {
     caching              = "ReadWrite"
     storage_account_type = "Premium_LRS"
-    disk_size_gb         = 20
+    disk_size_gb         = 30
   }
 
   source_image_reference {
@@ -123,7 +123,7 @@ resource "azurerm_linux_virtual_machine" "vm_ansible" {
   os_disk {
     caching              = "ReadWrite"
     storage_account_type = "Premium_LRS"
-    disk_size_gb         = 20
+    disk_size_gb         = 30
   }
 
   source_image_reference {


### PR DESCRIPTION
## 🔧 Correção de Disco para Debian 12

### 📋 Problema:
- Terraform Apply falhou com erro de disco muito pequeno
- Debian 12 requer mínimo 30GB de disco OS
- VMs vm-aprova-ai-3 e vm-aprova-ai-4 tinham apenas 20GB

### ✅ Solução:
- Aumentado `disk_size_gb` de 20 para 30GB
- Agora todas as VMs têm disco compatível com Debian 12

### 🎯 Resultado:
- ✅ vm-aprova-ai-1: 30GB (já estava correto)
- ✅ vm-aprova-ai-2: 50GB (já estava correto)  
- ✅ vm-aprova-ai-3: 30GB (corrigido)
- ✅ vm-aprova-ai-4: 30GB (corrigido)

### �� Status:
- 2 VMs já criadas na Azure (vm-1 e vm-2)
- 2 VMs pendentes (vm-3 e vm-4)