### PR TITLE
feat: add import step to sync existing resources with Terraform state

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -27,6 +27,44 @@ jobs:
     - name: Terraform Init
       run: terraform init
       
+    - name: Import Existing Resources
+      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+      run: |
+        echo "📥 Importando recursos existentes..."
+        
+        # Importar Resource Group
+        terraform import azurerm_resource_group.main /subscriptions/a346bbab-4a12-49d7-ac00-819eb93c7802/resourceGroups/rg-aprova-ai-prod-v2
+        
+        # Importar VNet
+        terraform import azurerm_virtual_network.main /subscriptions/a346bbab-4a12-49d7-ac00-819eb93c7802/resourceGroups/rg-aprova-ai-prod-v2/providers/Microsoft.Network/virtualNetworks/vnet-prod
+        
+        # Importar Subnet
+        terraform import azurerm_subnet.vm_subnet /subscriptions/a346bbab-4a12-49d7-ac00-819eb93c7802/resourceGroups/rg-aprova-ai-prod-v2/providers/Microsoft.Network/virtualNetworks/vnet-prod/subnets/snet-vm-prod
+        
+        # Importar Public IPs
+        terraform import azurerm_public_ip.vm_large /subscriptions/a346bbab-4a12-49d7-ac00-819eb93c7802/resourceGroups/rg-aprova-ai-prod-v2/providers/Microsoft.Network/publicIPAddresses/pip-vm-large-prod
+        terraform import azurerm_public_ip.vm_micro /subscriptions/a346bbab-4a12-49d7-ac00-819eb93c7802/resourceGroups/rg-aprova-ai-prod-v2/providers/Microsoft.Network/publicIPAddresses/pip-vm-micro-prod
+        terraform import azurerm_public_ip.vm_xlarge /subscriptions/a346bbab-4a12-49d7-ac00-819eb93c7802/resourceGroups/rg-aprova-ai-prod-v2/providers/Microsoft.Network/publicIPAddresses/pip-vm-xlarge-prod
+        terraform import azurerm_public_ip.vm_ansible /subscriptions/a346bbab-4a12-49d7-ac00-819eb93c7802/resourceGroups/rg-aprova-ai-prod-v2/providers/Microsoft.Network/publicIPAddresses/pip-vm-ansible-prod
+        
+        # Importar NSGs
+        terraform import azurerm_network_security_group.vm_large /subscriptions/a346bbab-4a12-49d7-ac00-819eb93c7802/resourceGroups/rg-aprova-ai-prod-v2/providers/Microsoft.Network/networkSecurityGroups/nsg-vm-large-prod
+        terraform import azurerm_network_security_group.vm_micro /subscriptions/a346bbab-4a12-49d7-ac00-819eb93c7802/resourceGroups/rg-aprova-ai-prod-v2/providers/Microsoft.Network/networkSecurityGroups/nsg-vm-micro-prod
+        terraform import azurerm_network_security_group.vm_xlarge /subscriptions/a346bbab-4a12-49d7-ac00-819eb93c7802/resourceGroups/rg-aprova-ai-prod-v2/providers/Microsoft.Network/networkSecurityGroups/nsg-vm-xlarge-prod
+        terraform import azurerm_network_security_group.vm_ansible /subscriptions/a346bbab-4a12-49d7-ac00-819eb93c7802/resourceGroups/rg-aprova-ai-prod-v2/providers/Microsoft.Network/networkSecurityGroups/nsg-vm-ansible-prod
+        
+        # Importar VMs
+        terraform import azurerm_linux_virtual_machine.vm_large /subscriptions/a346bbab-4a12-49d7-ac00-819eb93c7802/resourceGroups/rg-aprova-ai-prod-v2/providers/Microsoft.Compute/virtualMachines/vm-aprova-ai-1
+        terraform import azurerm_linux_virtual_machine.vm_micro /subscriptions/a346bbab-4a12-49d7-ac00-819eb93c7802/resourceGroups/rg-aprova-ai-prod-v2/providers/Microsoft.Compute/virtualMachines/vm-aprova-ai-2
+        terraform import azurerm_linux_virtual_machine.vm_xlarge /subscriptions/a346bbab-4a12-49d7-ac00-819eb93c7802/resourceGroups/rg-aprova-ai-prod-v2/providers/Microsoft.Compute/virtualMachines/vm-aprova-ai-3
+        terraform import azurerm_linux_virtual_machine.vm_ansible /subscriptions/a346bbab-4a12-49d7-ac00-819eb93c7802/resourceGroups/rg-aprova-ai-prod-v2/providers/Microsoft.Compute/virtualMachines/vm-aprova-ai-4
+        
+        echo "✅ Recursos importados com sucesso!"
+      env:
+        TF_VAR_ssh_public_key: ${{ secrets.SSH_PUBLIC_KEY }}
+        TF_VAR_admin_username: "azureuser"
+        TF_VAR_environment: "prod"
+      
     - name: Terraform Plan
       run: terraform plan
       env:


### PR DESCRIPTION
- Import all existing Azure resources before plan/apply
- This ensures Terraform knows about existing infrastructure
- Should resolve 'resource already exists' errors
- Will allow Terraform to detect only the disk size change needed