### PR TITLE
feat: update vm-aprova-ai-1 from Debian 12 to Ubuntu 22.04 LTS

### DIFF
--- a/virtual-machines.tf
+++ b/virtual-machines.tf
@@ -22,9 +22,9 @@ resource "azurerm_linux_virtual_machine" "vm_large" {
   }
 
   source_image_reference {
-    publisher = "Debian"
-    offer     = "debian-12"
-    sku       = "12"
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
     version   = "latest"
   }
   


### PR DESCRIPTION
- Change OS from Debian 12 to Ubuntu 22.04 LTS (Jammy Jellyfish)
- Keep same SSH key configuration
- NSG rule for port 8000 (Coolify) already exists
- VM will be recreated with new OS