### PR TITLE
feat: upgrade vm-aprova-ai-1 SKU from Standard_B2s to Standard_B4ms

### DIFF
--- a/virtual-machines.tf
+++ b/virtual-machines.tf
@@ -3,7 +3,7 @@ resource "azurerm_linux_virtual_machine" "vm_large" {
   name                = "vm-aprova-ai-1"
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
-  size                = "Standard_B2s"
+  size                = "Standard_B4ms"
   admin_username      = var.admin_username
   
   network_interface_ids = [


### PR DESCRIPTION
- Increase vCPUs from 2 to 4 (2x more)
- Increase RAM from 4GB to 16GB (4x more)
- Keep disk size at 200GB
- VM will be recreated with new specifications